### PR TITLE
Fix import on y2clerk

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,3 +35,5 @@ Depends:
 Suggests: 
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+Remotes:
+  y2analytics/y2clerk


### PR DESCRIPTION
This adds our githb repository to the sources of where to look for y2clerk when building the package. It will allow the package documentation and tests to work. 